### PR TITLE
feat: browser login persist session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ BOT_TOKEN=put-telegram-bot-token-here
 WB_PARTNER_URL=https://seller.wildberries.ru/
 WB_BASE_URL=https://example.wb-partner.ru   # TODO: заменить на реальный
 WB_SELLER_BASE=https://seller.wildberries.ru
+WB_SELLER_AUTH_URL=https://seller-auth.wildberries.ru/ru/?redirect_url=https%3A%2F%2Fseller.wildberries.ru%2F

--- a/src/bot_wb/handlers/_render.py
+++ b/src/bot_wb/handlers/_render.py
@@ -1,15 +1,17 @@
 from aiogram import Bot
 from aiogram.types import InlineKeyboardMarkup
 
+from ..services.auth_service import AuthService
 from ..storage.repo import UserRepo
 from ..ui.keyboards import kb_home, kb_profile
 from ..ui.texts import home_text, profile_text
 
 repo = UserRepo()
+_auth = AuthService(repo)
 
 
 async def render_home(bot: Bot, chat_id: int, user_name: str):
-    authorized = await repo.is_authorized(chat_id)
+    authorized = await _auth.is_authorized(chat_id)
     text = home_text(user_name, authorized)
     markup: InlineKeyboardMarkup = kb_home(authorized)
     await _edit_anchor(bot, chat_id, text, markup)

--- a/src/bot_wb/settings.py
+++ b/src/bot_wb/settings.py
@@ -11,6 +11,10 @@ class Settings:
     wb_base_url: str = os.getenv("WB_BASE_URL", "https://example.wb-partner.ru")
     wb_partner_url: str = os.getenv("WB_PARTNER_URL", "https://seller.wildberries.ru/")
     wb_seller_base: str = os.getenv("WB_SELLER_BASE", "https://seller.wildberries.ru")
+    wb_seller_auth_url: str = os.getenv(
+        "WB_SELLER_AUTH_URL",
+        "https://seller-auth.wildberries.ru/ru/?redirect_url=https%3A%2F%2Fseller.wildberries.ru%2F",
+    )
 
 
 def _build_settings() -> Settings:


### PR DESCRIPTION
## Summary
- open a headful Playwright window for WB Seller login and persist cookies per Telegram user
- add HTTP client that reuses stored cookies for subsequent API calls and updates auth state
- refresh bot UI and auth service to use the new browser flow and single-window messaging

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d4f8c427bc832ea5ccd807a30bd553