### PR TITLE
Add Telegram profile mini app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ WB_PARTNER_URL=https://seller.wildberries.ru/
 WB_BASE_URL=https://example.wb-partner.ru   # TODO: заменить на реальный
 WB_SELLER_BASE=https://seller.wildberries.ru
 WB_SELLER_AUTH_URL=https://seller-auth.wildberries.ru/ru/?redirect_url=https%3A%2F%2Fseller.wildberries.ru%2F
+WEBAPP_HOST=0.0.0.0
+WEBAPP_PORT=8080
+WEBAPP_PUBLIC_URL=http://localhost:8080

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,7 @@ loguru==0.7.2
 httpx==0.27.2
 aiosqlite==0.20.0
 playwright==1.47.0
+fastapi==0.115.0
+uvicorn==0.30.6
+jinja2==3.1.4
+itsdangerous==2.2.0

--- a/src/bot_wb/main.py
+++ b/src/bot_wb/main.py
@@ -1,16 +1,31 @@
 import asyncio
+from contextlib import suppress
+
+import uvicorn
 from aiogram import Bot, Dispatcher
 from aiogram.types import BotCommand
 
-from .settings import settings
-from .logger import logger
-from .storage.db import ensure_db
-from .handlers.start import router as start_router
 from .handlers.auth import router as auth_router
+from .handlers.start import router as start_router
+from .logger import logger
+from .settings import settings
+from .storage.db import ensure_db
+from .webapp_server import app as webapp
 
 
 async def setup_commands(bot: Bot):
     await bot.set_my_commands([BotCommand(command="start", description="Start")])
+
+
+async def run_webapp():
+    config = uvicorn.Config(
+        webapp,
+        host=settings.webapp_host,
+        port=settings.webapp_port,
+        log_level="info",
+    )
+    server = uvicorn.Server(config)
+    await server.serve()
 
 
 async def main():
@@ -21,7 +36,17 @@ async def main():
 
     await setup_commands(bot)
     logger.info("BOT_WB started")
-    await dp.start_polling(bot, allowed_updates=dp.resolve_used_update_types())
+    bot_task = asyncio.create_task(
+        dp.start_polling(bot, allowed_updates=dp.resolve_used_update_types())
+    )
+    web_task = asyncio.create_task(run_webapp())
+    _, pending = await asyncio.wait(
+        {bot_task, web_task}, return_when=asyncio.FIRST_COMPLETED
+    )
+    for task in pending:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
 
 if __name__ == "__main__":

--- a/src/bot_wb/settings.py
+++ b/src/bot_wb/settings.py
@@ -15,6 +15,9 @@ class Settings:
         "WB_SELLER_AUTH_URL",
         "https://seller-auth.wildberries.ru/ru/?redirect_url=https%3A%2F%2Fseller.wildberries.ru%2F",
     )
+    webapp_host: str = os.getenv("WEBAPP_HOST", "0.0.0.0")
+    webapp_port: int = int(os.getenv("WEBAPP_PORT", "8080"))
+    webapp_public_url: str = os.getenv("WEBAPP_PUBLIC_URL", "http://localhost:8080")
 
 
 def _build_settings() -> Settings:

--- a/src/bot_wb/storage/db.py
+++ b/src/bot_wb/storage/db.py
@@ -31,6 +31,8 @@ async def ensure_db():
             ("anchor_msg_id", "ALTER TABLE users ADD COLUMN anchor_msg_id INTEGER"),
             ("current_view", "ALTER TABLE users ADD COLUMN current_view TEXT"),
             ("api_token", "ALTER TABLE users ADD COLUMN api_token TEXT"),
+            ("profiles_json", "ALTER TABLE users ADD COLUMN profiles_json TEXT"),
+            ("active_profile_id", "ALTER TABLE users ADD COLUMN active_profile_id TEXT"),
         ]:
             if col not in cols:
                 await db.execute(ddl)

--- a/src/bot_wb/storage/repo.py
+++ b/src/bot_wb/storage/repo.py
@@ -1,3 +1,4 @@
+import json
 import aiosqlite
 
 from .db import DB_PATH
@@ -62,3 +63,22 @@ class UserRepo:
                 (tg_user_id,),
             )
             await db.commit()
+
+    async def set_profiles(self, tg_user_id: int, profiles: list[dict]):
+        await self.upsert(tg_user_id, profiles_json=json.dumps(profiles, ensure_ascii=False))
+
+    async def get_profiles(self, tg_user_id: int) -> list[dict]:
+        u = await self.get(tg_user_id)
+        if not u or not u.get("profiles_json"):
+            return []
+        try:
+            return json.loads(u["profiles_json"])
+        except Exception:
+            return []
+
+    async def set_active_profile(self, tg_user_id: int, profile_id: str):
+        await self.upsert(tg_user_id, active_profile_id=profile_id)
+
+    async def get_active_profile(self, tg_user_id: int) -> str | None:
+        u = await self.get(tg_user_id)
+        return u.get("active_profile_id") if u else None

--- a/src/bot_wb/ui/keyboards.py
+++ b/src/bot_wb/ui/keyboards.py
@@ -1,10 +1,17 @@
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
+
+from ..settings import settings
 
 
 def kb_home(authorized: bool) -> InlineKeyboardMarkup:
     row1 = []
     if authorized:
-        row1.append(InlineKeyboardButton(text="👤 Профиль", callback_data="profile"))
+        row1.append(
+            InlineKeyboardButton(
+                text="👤 Профиль",
+                web_app=WebAppInfo(url=f"{settings.webapp_public_url}/app/profile"),
+            )
+        )
     else:
         row1.append(InlineKeyboardButton(text="🔑 Авторизация", callback_data="auth"))
     row1.append(InlineKeyboardButton(text="🔄 Обновить", callback_data="refresh"))

--- a/src/bot_wb/webapp_server.py
+++ b/src/bot_wb/webapp_server.py
@@ -1,0 +1,99 @@
+import hashlib
+import hmac
+import urllib.parse
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from .services.wb_http_client import WBHttpClient
+from .settings import settings
+from .storage.repo import UserRepo
+
+app = FastAPI()
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+env = Environment(
+    loader=FileSystemLoader("templates"),
+    autoescape=select_autoescape(["html", "xml"]),
+)
+
+
+def _verify_init_data(init_data: str, bot_token: str) -> dict:
+    """Validate Telegram WebApp initData."""
+
+    parsed = dict(urllib.parse.parse_qsl(init_data, keep_blank_values=True))
+    hash_recv: Optional[str] = parsed.pop("hash", None)
+    data_check_string = "\n".join(f"{k}={v}" for k, v in sorted(parsed.items()))
+    secret_key = hashlib.sha256(f"WebAppData{bot_token}".encode()).digest()
+    h = hmac.new(secret_key, data_check_string.encode(), hashlib.sha256).hexdigest()
+    if h != hash_recv:
+        raise HTTPException(status_code=401, detail="Invalid initData hash")
+    if "user" in parsed:
+        import json
+
+        try:
+            parsed["user"] = json.loads(parsed["user"])
+        except Exception:
+            pass
+    return parsed
+
+
+@app.get("/app/profile", response_class=HTMLResponse)
+async def app_profile(request: Request, init_data: str):  # noqa: ARG001
+    _ = _verify_init_data(init_data, settings.bot_token)
+    template = env.get_template("profile_app.html")
+    return template.render(webapp_public_url=settings.webapp_public_url, init_data=init_data)
+
+
+@app.get("/api/profile/list")
+async def api_profile_list(init_data: str):
+    data = _verify_init_data(init_data, settings.bot_token)
+    tg_id = int(data["user"]["id"])
+    repo = UserRepo()
+
+    profiles = await repo.get_profiles(tg_id)
+    if not profiles:
+        client = WBHttpClient(tg_id)
+        try:
+            # TODO: заменить на реальное API WB Seller
+            # пример:
+            # js = await client.get_json("api/organizations")
+            # profiles = [
+            #     {
+            #         "id": x["id"],
+            #         "name": x["name"],
+            #         "inn": x.get("inn", ""),
+            #         "status": x.get("status", ""),
+            #     }
+            #     for x in js
+            # ]
+            profiles = [
+                {"id": "default", "name": "Аккаунт WB Seller", "inn": "", "status": "active"}
+            ]
+        finally:
+            await client.aclose()
+        await repo.set_profiles(tg_id, profiles)
+
+    active_id = await repo.get_active_profile(tg_id)
+    return JSONResponse({"profiles": profiles, "active_profile_id": active_id})
+
+
+@app.post("/api/profile/select")
+async def api_profile_select(request: Request):
+    body = await request.json()
+    init_data = body.get("init_data")
+    profile_id = body.get("profile_id")
+    if not init_data:
+        raise HTTPException(status_code=400, detail="init_data required")
+    if not profile_id:
+        raise HTTPException(status_code=400, detail="profile_id required")
+
+    data = _verify_init_data(init_data, settings.bot_token)
+    tg_id = int(data["user"]["id"])
+
+    repo = UserRepo()
+    await repo.set_active_profile(tg_id, profile_id)
+    return JSONResponse({"ok": True})

--- a/templates/profile_app.html
+++ b/templates/profile_app.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Профили WB Seller</title>
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <style>
+    body{font-family:system-ui,Arial,sans-serif;margin:0;padding:12px;}
+    .card{border-radius:12px; padding:12px; margin-bottom:12px; box-shadow:0 1px 4px rgba(0,0,0,.06);}
+    .active{outline:2px solid #4caf50;}
+    .btn{display:inline-block;padding:10px 14px;border-radius:10px;border:0;background:#4caf50;color:#fff;cursor:pointer;}
+    .btn.secondary{background:#607d8b}
+    .row{display:flex;gap:8px;flex-wrap:wrap}
+    .muted{color:#777}
+  </style>
+</head>
+<body>
+  <h3>Профили WB Seller</h3>
+  <div id="list"></div>
+  <div class="row">
+    <button class="btn secondary" id="close">Закрыть</button>
+  </div>
+
+<script>
+const tg = window.Telegram.WebApp;
+tg.expand();
+
+const INIT_DATA = "{{ init_data|e }}";
+const BASE = "{{ webapp_public_url|e }}";
+
+async function fetchJSON(url, opts){
+  const r = await fetch(url, opts);
+  if(!r.ok) throw new Error("HTTP "+r.status);
+  return await r.json();
+}
+
+function render(profiles, activeId){
+  const list = document.getElementById('list');
+  list.innerHTML = '';
+  profiles.forEach(p=>{
+    const div = document.createElement('div');
+    div.className = 'card'+(p.id===activeId?' active':'');
+    div.innerHTML = `
+      <div><b>${p.name}</b></div>
+      <div class="muted">${p.inn?('ИНН: '+p.inn):''}</div>
+      <div class="muted">${p.status?('Статус: '+p.status):''}</div>
+      <div class="row" style="margin-top:8px;">
+        <button class="btn" data-id="${p.id}">${p.id===activeId?'Выбран':'Выбрать'}</button>
+      </div>
+    `;
+    div.querySelector('button').onclick = async (ev)=>{
+      const id = ev.currentTarget.getAttribute('data-id');
+      await fetchJSON(BASE+'/api/profile/select', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({init_data: INIT_DATA, profile_id: id})
+      });
+      load();
+      tg.HapticFeedback.impactOccurred('light');
+    };
+    list.appendChild(div);
+  });
+}
+
+async function load(){
+  const data = await fetchJSON(BASE+'/api/profile/list?init_data='+encodeURIComponent(INIT_DATA));
+  render(data.profiles || [], data.active_profile_id || null);
+}
+
+document.getElementById('close').onclick = ()=> tg.close();
+
+load();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI-based Telegram WebApp server for managing WB Seller profiles and validating initData
- persist cached profiles and active profile selection for each Telegram user
- expose profile mini app via inline keyboard button and run the web server alongside the bot

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d4fcf28824832ea06812d63bc7b2ec