### PR TITLE
Implement inline profile view without web app

### DIFF
--- a/src/bot_wb/handlers/__init__.py
+++ b/src/bot_wb/handlers/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["start", "auth"]
+__all__ = ["start", "auth", "profile"]

--- a/src/bot_wb/handlers/_render.py
+++ b/src/bot_wb/handlers/_render.py
@@ -3,8 +3,8 @@ from aiogram.types import InlineKeyboardMarkup
 
 from ..services.auth_service import AuthService
 from ..storage.repo import UserRepo
-from ..ui.keyboards import kb_home, kb_profile
-from ..ui.texts import home_text, profile_text
+from ..ui.keyboards import kb_home
+from ..ui.texts import home_text
 
 repo = UserRepo()
 _auth = AuthService(repo)
@@ -16,14 +16,6 @@ async def render_home(bot: Bot, chat_id: int, user_name: str):
     markup: InlineKeyboardMarkup = kb_home(authorized)
     await _edit_anchor(bot, chat_id, text, markup)
     await repo.set_view(chat_id, "home")
-
-
-async def render_profile(bot: Bot, chat_id: int):
-    user = await repo.get(chat_id)
-    text = profile_text(user.get("profile_org") if user else None)
-    markup = kb_profile()
-    await _edit_anchor(bot, chat_id, text, markup)
-    await repo.set_view(chat_id, "profile")
 
 
 async def _edit_anchor(bot: Bot, chat_id: int, text: str, markup: InlineKeyboardMarkup | None):

--- a/src/bot_wb/handlers/auth.py
+++ b/src/bot_wb/handlers/auth.py
@@ -6,7 +6,7 @@ from ..services.auth_service import AuthService
 from ..storage.repo import UserRepo
 from ..ui import texts
 from ..ui.keyboards import kb_home
-from ._render import render_home, render_profile
+from ._render import render_home
 
 router = Router(name=__name__)
 _repo = UserRepo()
@@ -37,12 +37,6 @@ async def on_auth(cb: CallbackQuery, state: FSMContext):
         )
 
 
-@router.callback_query(F.data == "profile")
-async def on_profile(cb: CallbackQuery):
-    await render_profile(cb.bot, cb.message.chat.id)
-    await cb.answer()
-
-
 @router.callback_query(F.data == "logout")
 async def logout(cb: CallbackQuery, state: FSMContext):
     await _auth.logout(cb.from_user.id)
@@ -64,7 +58,8 @@ async def refresh(cb: CallbackQuery):
     view = await _repo.get_view(cb.from_user.id)
     user_name = cb.from_user.full_name if cb.from_user else "друг"
     if view == "profile":
-        await render_profile(cb.bot, cb.message.chat.id)
+        await cb.answer("Используйте кнопку \"Обновить\" в профиле", show_alert=True)
+        return
     else:
         await render_home(cb.bot, cb.message.chat.id, user_name)
     await cb.answer()

--- a/src/bot_wb/handlers/profile.py
+++ b/src/bot_wb/handlers/profile.py
@@ -1,0 +1,94 @@
+from aiogram import F, Router
+from aiogram.types import CallbackQuery
+
+from ..services.wb_http_client import WBHttpClient
+from ..storage.repo import UserRepo
+from ..ui import texts
+from ..ui.keyboards import kb_profile_switch, kb_profile_view
+
+router = Router(name=__name__)
+_repo = UserRepo()
+
+
+async def _render_profile(cb: CallbackQuery):
+    if not cb.message:
+        return
+    tg_id = cb.from_user.id
+    profiles = await _repo.get_profiles(tg_id)
+    if not profiles:
+        client = WBHttpClient(tg_id)
+        try:
+            profiles = await client.list_organizations()
+        finally:
+            await client.aclose()
+        await _repo.set_profiles(tg_id, profiles)
+        if len(profiles) == 1:
+            first_id = profiles[0].get("id")
+            if first_id is not None:
+                await _repo.set_active_profile(tg_id, str(first_id))
+
+    active_id = await _repo.get_active_profile(tg_id)
+
+    if len(profiles) <= 1:
+        org_name = profiles[0].get("name") if profiles else None
+        text = texts.profile_text_single(org_name)
+        markup = kb_profile_view(has_multiple=False)
+    else:
+        text = texts.profile_text_multi(profiles, active_id)
+        markup = kb_profile_view(has_multiple=True)
+
+    await cb.message.edit_text(text=text, reply_markup=markup)
+    await _repo.set_view(tg_id, "profile")
+
+
+@router.callback_query(F.data == "profile")
+async def on_profile(cb: CallbackQuery):
+    await _render_profile(cb)
+    await cb.answer()
+
+
+@router.callback_query(F.data == "profile_refresh")
+async def on_profile_refresh(cb: CallbackQuery):
+    await _render_profile(cb)
+    await cb.answer("Обновлено")
+
+
+@router.callback_query(F.data == "profile_switch")
+async def on_profile_switch(cb: CallbackQuery):
+    tg_id = cb.from_user.id
+    profiles = await _repo.get_profiles(tg_id)
+    active_id = await _repo.get_active_profile(tg_id)
+    if not profiles:
+        await cb.answer("Профили не найдены", show_alert=True)
+        return
+    if not cb.message:
+        await cb.answer()
+        return
+    await cb.message.edit_text(
+        text="Выберите профиль для работы:",
+        reply_markup=kb_profile_switch(
+            [(str(p.get("id") or ""), p.get("name") or "—") for p in profiles],
+            active_id,
+        ),
+    )
+    await cb.answer()
+
+
+@router.callback_query(F.data.startswith("set_profile:"))
+async def on_set_profile(cb: CallbackQuery):
+    pid = cb.data.split(":", 1)[1]
+    tg_id = cb.from_user.id
+
+    client = WBHttpClient(tg_id)
+    ok = True
+    try:
+        ok = await client.set_active_organization(pid)
+    finally:
+        await client.aclose()
+
+    if ok:
+        await _repo.set_active_profile(tg_id, pid)
+        await cb.answer("Профиль выбран")
+        await _render_profile(cb)
+    else:
+        await cb.answer("Не удалось сменить профиль", show_alert=True)

--- a/src/bot_wb/main.py
+++ b/src/bot_wb/main.py
@@ -6,6 +6,7 @@ from aiogram import Bot, Dispatcher
 from aiogram.types import BotCommand
 
 from .handlers.auth import router as auth_router
+from .handlers.profile import router as profile_router
 from .handlers.start import router as start_router
 from .logger import logger
 from .settings import settings
@@ -32,7 +33,7 @@ async def main():
     await ensure_db()
     bot = Bot(token=settings.bot_token)
     dp = Dispatcher()
-    dp.include_routers(start_router, auth_router)
+    dp.include_routers(start_router, auth_router, profile_router)
 
     await setup_commands(bot)
     logger.info("BOT_WB started")

--- a/src/bot_wb/services/auth_service.py
+++ b/src/bot_wb/services/auth_service.py
@@ -29,9 +29,16 @@ class AuthService:
         if ok:
             client = WBHttpClient(tg_id)
             try:
-                org = await client.get_organization_name()
-                if org:
-                    await self.repo.set_profile_org(tg_id, org)
+                profiles = await client.list_organizations()
+                await self.repo.set_profiles(tg_id, profiles)
+                if profiles:
+                    await self.repo.set_active_profile(tg_id, profiles[0]["id"])
+                    if profiles[0].get("name"):
+                        await self.repo.set_profile_org(tg_id, profiles[0]["name"])
+                else:
+                    org = await client.get_organization_name()
+                    if org:
+                        await self.repo.set_profile_org(tg_id, org)
                 await self.repo.set_authorized(tg_id, True)
             finally:
                 await client.aclose()

--- a/src/bot_wb/services/wb_http_client.py
+++ b/src/bot_wb/services/wb_http_client.py
@@ -60,3 +60,18 @@ class WBHttpClient:
         except Exception:
             pass
         return None
+
+    async def list_organizations(self) -> list[dict]:
+        """
+        TODO: заменить на реальное API WB Seller.
+        Пока возвращаем 1 профиль — имя из get_organization_name().
+        """
+        name = await self.get_organization_name()
+        return [{"id": "default", "name": name or "Аккаунт WB Seller", "inn": ""}]
+
+    async def set_active_organization(self, org_id: str) -> bool:
+        """
+        TODO: если у WB действительно есть переключение юрлиц в одном логине — тут вызвать их API.
+        Пока возвращаем True без запроса.
+        """
+        return True

--- a/src/bot_wb/storage/repo.py
+++ b/src/bot_wb/storage/repo.py
@@ -58,7 +58,8 @@ class UserRepo:
         async with aiosqlite.connect(self._db_path) as db:
             await db.execute(
                 "UPDATE users SET phone=NULL,email=NULL,cookies=NULL,api_token=NULL,"
-                "is_authorized=0,profile_org=NULL,current_view=NULL,updated_at=CURRENT_TIMESTAMP "
+                "is_authorized=0,profile_org=NULL,current_view=NULL,profiles_json=NULL,"
+                "active_profile_id=NULL,updated_at=CURRENT_TIMESTAMP "
                 "WHERE tg_user_id=?",
                 (tg_user_id,),
             )

--- a/src/bot_wb/ui/keyboards.py
+++ b/src/bot_wb/ui/keyboards.py
@@ -1,23 +1,17 @@
-from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
-
-from ..settings import settings
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 
 def kb_home(authorized: bool) -> InlineKeyboardMarkup:
     row1 = []
     if authorized:
-        row1.append(
-            InlineKeyboardButton(
-                text="👤 Профиль",
-                web_app=WebAppInfo(url=f"{settings.webapp_public_url}/app/profile"),
-            )
-        )
+        row1.append(InlineKeyboardButton(text="👤 Профиль", callback_data="profile"))
+        # ВАЖНО: на главном больше ничего не добавляем, ты просил только Профиль/Домой/Закрыть (Домой = этот экран)
     else:
         row1.append(InlineKeyboardButton(text="🔑 Авторизация", callback_data="auth"))
-    row1.append(InlineKeyboardButton(text="🔄 Обновить", callback_data="refresh"))
+    # Домой = этот экран, отдельной кнопки не нужно — мы и так «дома»
     return InlineKeyboardMarkup(
         inline_keyboard=[
-            row1,
+            [*row1],
             [InlineKeyboardButton(text="❌ Закрыть", callback_data="close")],
         ]
     )
@@ -34,13 +28,28 @@ def kb_auth_stub() -> InlineKeyboardMarkup:
     )
 
 
-def kb_profile() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(
-        inline_keyboard=[
-            [InlineKeyboardButton(text="🚪 Выйти из аккаунта", callback_data="logout")],
-            [
-                InlineKeyboardButton(text="🏠 Домой", callback_data="home"),
-                InlineKeyboardButton(text="❌ Закрыть", callback_data="close"),
-            ],
-        ]
-    )
+def kb_profile_view(has_multiple: bool) -> InlineKeyboardMarkup:
+    rows = []
+    # В профиле должны быть кнопки: Сменить профиль, Выйти, Домой, Обновить, Закрыть
+    if has_multiple:
+        rows.append([InlineKeyboardButton(text="🔀 Сменить профиль", callback_data="profile_switch")])
+    rows.append([InlineKeyboardButton(text="🚪 Выйти с аккаунта", callback_data="logout")])
+    rows.append([
+        InlineKeyboardButton(text="🏠 Домой", callback_data="home"),
+        InlineKeyboardButton(text="🔄 Обновить", callback_data="profile_refresh"),
+    ])
+    rows.append([InlineKeyboardButton(text="❌ Закрыть", callback_data="close")])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def kb_profile_switch(profiles: list[tuple[str, str]], active_id: str | None) -> InlineKeyboardMarkup:
+    # profiles: список (id, name)
+    kb: list[list[InlineKeyboardButton]] = []
+    for pid, name in profiles:
+        label = f"✅ {name}" if pid == active_id else f"{name}"
+        kb.append([InlineKeyboardButton(text=label, callback_data=f"set_profile:{pid}")])
+    kb.append([
+        InlineKeyboardButton(text="⬅️ Назад", callback_data="profile"),
+        InlineKeyboardButton(text="❌ Закрыть", callback_data="close")
+    ])
+    return InlineKeyboardMarkup(inline_keyboard=kb)

--- a/src/bot_wb/ui/texts.py
+++ b/src/bot_wb/ui/texts.py
@@ -26,9 +26,19 @@ def auth_success_text() -> str:
     return "✅ Авторизация выполнена. Аккаунт привязан к вашему Telegram."
 
 
-def profile_text(org: str | None) -> str:
-    org_line = f"Организация: {org}" if org else "Организация: —"
-    return f"👤 Профиль WB Partner\n{org_line}"
+def profile_text_single(org_name: str | None) -> str:
+    org_line = f"Организация: {org_name}" if org_name else "Организация: —"
+    return f"👤 Профиль WB Seller\n{org_line}"
+
+
+def profile_text_multi(orgs: list[dict], active_id: str | None) -> str:
+    lines = ["👤 Профили WB Seller:"]
+    for x in orgs:
+        mark = "✅" if x.get("id") == active_id else "•"
+        name = x.get("name") or "—"
+        inn = f" (ИНН {x.get('inn')})" if x.get("inn") else ""
+        lines.append(f"{mark} {name}{inn} — id: {x.get('id')}")
+    return "\n".join(lines)
 
 
 def logout_done_text() -> str:


### PR DESCRIPTION
## Summary
- replace the profile web app entry point with inline keyboards for home and profile screens
- implement profile callbacks that render organization info, switching, refreshing, and logout controls
- extend WB client stubs, repository storage, and auth flow to cache organization profiles and active selections

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d5044e02c4832e8e035779767a003e