### PR TITLE
Fix src layout imports and update tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
           source .venv/bin/activate
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
+      - name: Editable install
+        run: |
+          source .venv/bin/activate
+          pip install -e .
       - name: Ruff
         run: |
           source .venv/bin/activate

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.sqlite3
 *.db
 *.log
+.egg-info/
 .venv/
 .env
 .env.*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: run dev-install run-m
+
+run:
+	python main.py
+
+dev-install:
+	pip install -e .
+
+run-m:
+	python -m bot_wb.main

--- a/README.md
+++ b/README.md
@@ -8,11 +8,21 @@
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements-dev.txt
+pip install -e .
 cp .env.example .env
 # заполните BOT_TOKEN и другие переменные
 python -m playwright install chromium
-PYTHONPATH=src python -m bot_wb.main
+python -m bot_wb.main
 ```
+
+## ▶️ Запуск
+
+Способ A (быстрый):
+    python main.py
+
+Способ B (рекомендуемый для разработки):
+    pip install -e .
+    python -m bot_wb.main
 
 ## ⚙️ Переменные окружения
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,17 @@
-from src.bot_wb.main import main
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    # Делает пакет bot_wb видимым для локального запуска "python main.py"
+    sys.path.insert(0, str(SRC))
+
+from bot_wb.main import main  # noqa: E402
+
 
 if __name__ == "__main__":
-    import asyncio
-
     asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,31 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=69", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "bot-wb"
+version = "0.1.0"
+requires-python = ">=3.11"
+# dependencies: при необходимости синхронизируй с requirements.txt
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["bot_wb*"]
+
 [tool.black]
-line-length = 88
+line-length = 100
 target-version = ["py311"]
 
 [tool.isort]
 profile = "black"
-line_length = 88
+line_length = 100
 known_first_party = ["bot_wb"]
 
 [tool.ruff]
-line-length = 88
+line-length = 100
 src = ["src", "tests"]
 target-version = "py311"
 
@@ -50,7 +63,6 @@ show_error_codes = true
 
 [tool.pytest.ini_options]
 addopts = "-q"
-asyncio_mode = "auto"
 testpaths = ["tests"]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary
- make the root bootstrap script add `src` to `sys.path` for local runs
- configure setuptools for the `src` layout and refresh developer tooling/docs
- add editable install step to CI along with convenience make targets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5363230a0832eacc447fa26e08e6f