### PR TITLE
Fix entrypoints and docs for bot_wb package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pip install -e .
 cp .env.example .env
 # заполните BOT_TOKEN и другие переменные
 python -m playwright install chromium
-python -m bot_wb.main
+python -m bot_wb
 ```
 
 ## ▶️ Запуск
@@ -22,7 +22,7 @@ python -m bot_wb.main
 
 Способ B (рекомендуемый для разработки):
     pip install -e .
-    python -m bot_wb.main
+    python -m bot_wb
 
 ## ⚙️ Переменные окружения
 

--- a/main.py
+++ b/main.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-import pathlib
 import sys
+from pathlib import Path
 
-ROOT = pathlib.Path(__file__).resolve().parent
+ROOT = Path(__file__).resolve().parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
-    # Делает пакет bot_wb видимым для локального запуска "python main.py"
     sys.path.insert(0, str(SRC))
 
 from bot_wb.main import main  # noqa: E402

--- a/src/bot_wb/__main__.py
+++ b/src/bot_wb/__main__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import asyncio
+
+from .main import main
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- update the repository root main.py to configure the src directory on sys.path and delegate to bot_wb.main
- add a package entrypoint at src/bot_wb/__main__.py so the project can be launched with python -m bot_wb
- refresh README launch instructions to mention both python main.py and python -m bot_wb

## Testing
- pytest *(fails: missing dependency respx in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d53b7c72b8832ea9355ccf05a46a50