### PR TITLE
Update aiogram bot defaults for v3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ python -m playwright install chromium
 python -m bot_wb
 ```
 
+> Проект рассчитан на `aiogram` версии `3.7` и выше (до `4.0`).
+> Параметры `parse_mode`/`disable_web_page_preview`/`protect_content`
+> настраиваются через `DefaultBotProperties` при создании экземпляра `Bot`.
+
 ## ▶️ Запуск
 
 Способ A (быстрый):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ pre-commit==4.0.1
 pytest==8.3.3
 pytest-asyncio==0.23.8
 respx==0.21.1
-aiohttp==3.10.10
+aiohttp==3.12.14
 aiogram-tests==1.0.3
 ruff==0.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiogram==3.13.1
+aiogram>=3.7.0,<4
 python-dotenv==1.0.1
 loguru>=0.7.0
 httpx==0.27.2

--- a/src/bot_wb/main.py
+++ b/src/bot_wb/main.py
@@ -2,6 +2,8 @@ import asyncio
 from contextlib import suppress
 
 from aiogram import Bot, Dispatcher
+from aiogram.client.default import DefaultBotProperties
+from aiogram.enums import ParseMode
 from aiogram.types import BotCommand
 
 from .handlers.auth import router as auth_router
@@ -35,7 +37,10 @@ async def main() -> None:
     dp.include_routers(start_router, auth_router, profile_router)
     _setup_middlewares(dp)
 
-    bot = Bot(token=settings.bot_token, parse_mode="HTML")
+    bot = Bot(
+        token=settings.bot_token,
+        default=DefaultBotProperties(parse_mode=ParseMode.HTML),
+    )
 
     await setup_commands(bot)
     logger.info("BOT_WB started")


### PR DESCRIPTION
## Summary
- switch bot instantiation to use DefaultBotProperties with ParseMode.HTML for aiogram 3.7+
- bump the aiogram requirement to the >=3.7,<4 range and align dev requirements
- document the new aiogram requirement and default bot property configuration in the README

## Testing
- pip install -r requirements.txt -r requirements-dev.txt
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d544279ce8832eb46e8434a4480010